### PR TITLE
Updating Readme and api changes

### DIFF
--- a/test/enum.js
+++ b/test/enum.js
@@ -32,13 +32,13 @@ describe('Enums', function () {
     done()
   })
 
-  it('should use passed arg with invalid enum and no fallback', function (done) {
+  it('should use passed arg with invalid enum and no default', function (done) {
     const commandLineArguments = {
-      noFall: 'sometimes'
+      noDefault: 'sometimes'
     }
 
     sourceConfig.init({ schema, commandLineArguments })
-    assert.deepStrictEqual(sourceConfig.configs.enumWithoutFallback, 'sometimes')
+    assert.deepStrictEqual(sourceConfig.configs.enumWithoutDefault, null)
     done()
   })
 })

--- a/test/schema.json
+++ b/test/schema.json
@@ -27,18 +27,12 @@
     "commandLineArg": "httpMethod",
     "desc": "example enum",
     "default": "http",
-    "acceptedValues": {
-      "values": ["http", "https"],
-      "fallback": "http"
-    }
+    "values": ["http", "https"]
   },
-  "enumWithoutFallback": {
-    "commandLineArg": "noFall",
-    "desc": "enum with no fallback",
-    "default": "yes",
-    "acceptedValues": {
-      "values": ["yes", "no"]
-    }
+  "enumWithoutDefault": {
+    "commandLineArg": "noDefault",
+    "desc": "enum with no default",
+    "values": ["yes", "no"]
   },
   "webUrlObj": {
     "httpMethod": {


### PR DESCRIPTION
I've updated the README to resolve a few instances which needed examples. This included

* Example for using command line arguments (#8)
* Example for using both methods of envVarParser
* Example for config property that is composed from other config props

As well, I updated a few other parts of the codebase that were dicsussed

* Switched enum type for config prop to simplified array (#6)
* Allowed config items to be defined as an empty object (#7)
* returned configs on init() (#9)

With this, I as well made small tweaks to make sure the tests passed.